### PR TITLE
Allow run.run() to run Watchers, and introduce watcher threading

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -5,6 +5,7 @@ publishers = {}
 runningCollectors = {}
 runningPublishers = {}
 data = {}
+lock = threading.Lock()
 
 def run(saveSync = 0):
     """
@@ -14,7 +15,7 @@ def run(saveSync = 0):
     data['lastSync'] = int(time.time())
     for i in collectors:
         runningCollectors[i] = threading.Thread(target=collectors[i]["function"], kwargs={"interval":collectors[i]["interval"], "repeat":collectors[i]["repeat"], "name":i}).start()
-        
+    #DATA access must use the with lock: statement to accuretly access the data.
 
 def updateTime():
     """

--- a/src/run.py
+++ b/src/run.py
@@ -13,7 +13,7 @@ def run(saveSync = 0):
     """
     data['lastSync'] = int(time.time())
     for i in collectors:
-        runningCollectors[i] = threading.Thread(target=collectors[i]["function"], kwargs={"interval":collectors[i]["interval"], "repeat":collectors[i]["repeat"]}).start()
+        runningCollectors[i] = threading.Thread(target=collectors[i]["function"], kwargs={"interval":collectors[i]["interval"], "repeat":collectors[i]["repeat"], "name":i}).start()
         
 
 def updateTime():

--- a/src/run.py
+++ b/src/run.py
@@ -4,7 +4,7 @@ collectors = {}
 publishers = {}
 runningCollectors = {}
 runningPublishers = {}
-data = {"lastSync": 0, "test": {"offset": 1}, "test2": {"offset": 2}}
+data = {}
 
 def run(saveSync = 0):
     """

--- a/src/run.py
+++ b/src/run.py
@@ -1,0 +1,30 @@
+import time, math, threading
+
+collectors = {}
+publishers = {}
+runningCollectors = {}
+runningPublishers = {}
+data = {"lastSync": 0, "test": {"offset": 1}, "test2": {"offset": 2}}
+
+def run(saveSync = 0):
+    """
+    Run the application.
+    saveSync: 0 = Save when all values are updated, 1 = save with cached data on updated data, 2 = save only updated values when a value is updated Only applies to collectors that support it.
+    """
+    data['lastSync'] = int(time.time())
+    for i in collectors:
+        runningCollectors[i] = threading.Thread(target=collectors[i]["function"], kwargs={"interval":collectors[i]["interval"], "repeat":collectors[i]["repeat"]}).start()
+        
+
+def updateTime():
+    """
+    Update the last sync time.
+    """
+    minOffset = math.inf
+    for item in data:
+        if item != 'lastSync' and data[item]["offset"] < minOffset:
+            minOffset = data[item]["offset"]
+    data['lastSync'] += minOffset
+    for item in data:
+        if item != 'lastSync':
+            data[item]["offset"] -= minOffset

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -3,7 +3,7 @@ import math, time, src.run as run
 def watcher(original_function, name, interval=1, repeat=math.inf):
     """Backend function for watcher decorator"""
     def collector(interval, repeat):
-        """Backend function for watcher decorator"""
+        """Backend function for dealing with watcher timing"""
         count = 0
         while count < repeat:
             count += 1

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -1,12 +1,15 @@
-import time, math
+import math, time, src.run as run
 
 def watcher(original_function, name, interval=1, repeat=math.inf):
     """Backend function for watcher decorator"""
-    count = 0
-    while count < repeat:
-        time.sleep(interval)
-        return_value = original_function()
-        count += 1
+    def collector(interval, repeat):
+        """Backend function for watcher decorator"""
+        count = 0
+        while count < repeat:
+            count += 1
+            original_function()
+            time.sleep(interval)
+    run.collectors[name] = {"function":collector, "interval": interval, "repeat": repeat}
 
 def newWatcher(interval=1, repeat=math.inf):
     """

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -2,12 +2,12 @@ import math, time, src.run as run
 
 def watcher(original_function, name, interval=1, repeat=math.inf):
     """Backend function for watcher decorator"""
-    def collector(interval, repeat):
+    def collector(interval, repeat, name):
         """Backend function for dealing with watcher timing"""
         count = 0
         while count < repeat:
             count += 1
-            original_function()
+            run.data[name] = {"data":original_function(), "offset": int(time.time()) - run.data['lastSync']}
             time.sleep(interval)
     run.collectors[name] = {"function":collector, "interval": interval, "repeat": repeat}
 

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -7,7 +7,8 @@ def watcher(original_function, name, interval=1, repeat=math.inf):
         count = 0
         while count < repeat:
             count += 1
-            run.data[name] = {"data":original_function(), "offset": int(time.time()) - run.data['lastSync']}
+            with run.lock:
+                run.data[name] = {"data":original_function(), "offset": int(time.time()) - run.data['lastSync']}
             time.sleep(interval)
     run.collectors[name] = {"function":collector, "interval": interval, "repeat": repeat}
 


### PR DESCRIPTION
- Added an update time function to update all the time offsets
- Allowed run to actually run the collectors instead of the collectors running themselves
- Added threading to collectors so multiple can run at the same time
- Allowed collectors to return data